### PR TITLE
Use relative URLs so preview deploys stay on their own domain

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
   <div class="posts">
     {{ range .Pages }}
       <div class="post on-list">
-        <h1 class="content-large"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h1>
+        <h1 class="content-large"><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></h1>
         <div class="post-meta">
           {{ if .Date }}
             <span class="post-date">
@@ -29,7 +29,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-              <a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">#{{ . }}</a>&nbsp;
+              <a href="{{ (urlize (printf "tags/%s" . )) | relURL }}/">#{{ . }}</a>&nbsp;
             {{ end }}
           </span>
         {{ end }}
@@ -37,9 +37,9 @@
         {{ if .Params.Cover }}
           <figure class="post-cover">
          {{ if .Params.UseRelativeCover }}
-            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+            <img src="{{ (printf "%s%s" .RelPermalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
           {{ else }}
-            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+            <img src="{{ .Params.Cover | relURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
             {{ end }}
 
             {{ if .Params.CoverCaption }}

--- a/layouts/_default/questions.html
+++ b/layouts/_default/questions.html
@@ -16,12 +16,12 @@
 
     {{ range .Pages.Reverse }}
       <div class="post on-list">
-        <span class="content-large"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></span>
+        <span class="content-large"><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></span>
 
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-              <a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">#{{ . }}</a>&nbsp;
+              <a href="{{ (urlize (printf "tags/%s" . )) | relURL }}/">#{{ . }}</a>&nbsp;
             {{ end }}
           </span>
         {{ end }}
@@ -29,9 +29,9 @@
         {{ if .Params.Cover }}
           <figure class="post-cover">
          {{ if .Params.UseRelativeCover }}
-            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+            <img src="{{ (printf "%s%s" .RelPermalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
           {{ else }}
-            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+            <img src="{{ .Params.Cover | relURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
             {{ end }}
 
             {{ if .Params.CoverCaption }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -33,7 +33,7 @@
     {{ if .Params.tags }}
       <span class="post-tags">
         {{ range .Params.tags }}
-          <a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">#{{ . }}</a>&nbsp;
+          <a href="{{ (urlize (printf "tags/%s" . )) | relURL }}/">#{{ . }}</a>&nbsp;
         {{ end }}
       </span>
     {{ end }}
@@ -41,9 +41,9 @@
     {{ if .Params.Cover }}
       <figure class="post-cover">
         {{ if .Params.UseRelativeCover }}
-          <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+          <img src="{{ (printf "%s%s" .RelPermalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
         {{ else }}
-          <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+          <img src="{{ .Params.Cover | relURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
         {{ end }}
 
         {{ if .Params.CoverCaption }}
@@ -71,7 +71,7 @@
           <div class="pagination__buttons">
             {{ if .NextInSection }}
               <span class="button previous">
-                <a href="{{ .NextInSection.Permalink }}">
+                <a href="{{ .NextInSection.RelPermalink }}">
                   <span class="button__icon">←</span>
                   <span class="button__text">{{ .NextInSection.Title }}</span>
                 </a>
@@ -79,7 +79,7 @@
             {{ end }}
             {{ if .PrevInSection }}
               <span class="button next">
-                <a href="{{ .PrevInSection.Permalink }}">
+                <a href="{{ .PrevInSection.RelPermalink }}">
                   <span class="button__text">{{ .PrevInSection.Title }}</span>
                   <span class="button__icon">→</span>
                 </a>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,13 +7,13 @@
 <link rel="canonical" href="{{ .Permalink }}" />
 
 <!-- Theme CSS -->
-<link rel="stylesheet" href="{{ "assets/style.css" | absURL }}" />
-<link rel="stylesheet" href="{{ "assets/nova.css" | absURL }}" />
-<link rel="preload" href="{{ "assets/fonts/FiraCode-VariableFont_wght.ttf" | absURL }}" as="font" type="font/ttf" crossorigin>
+<link rel="stylesheet" href="{{ "assets/style.css" | relURL }}" />
+<link rel="stylesheet" href="{{ "assets/nova.css" | relURL }}" />
+<link rel="preload" href="{{ "assets/fonts/FiraCode-VariableFont_wght.ttf" | relURL }}" as="font" type="font/ttf" crossorigin>
 
 
 <!-- Icons -->
-<link rel="shortcut icon" href="{{ "favicon.ico" | absURL }}" />
+<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}" />
 
 {{ if .IsHome  }}
   {{- partial "head_meta_twitter_large.html" . }}

--- a/layouts/partials/main.html
+++ b/layouts/partials/main.html
@@ -3,7 +3,7 @@ Posts
     <ul>
         {{ range . }}
             <li>
-                <a href="{{ .Permalink }}">{{ .Date.Format "2006-01-02" }} {{ .Title | markdownify }}</li>
+                <a href="{{ .RelPermalink }}">{{ .Date.Format "2006-01-02" }} {{ .Title | markdownify }}</li>
         {{ end }}
     </ul>
 </div>

--- a/layouts/shortcodes/toc.html
+++ b/layouts/shortcodes/toc.html
@@ -3,7 +3,7 @@
   {{ range .Site.Pages }}
     {{ if in .Params.series $series }}
       <li>
-        <a href="{{ .Permalink }}">
+        <a href="{{ .RelPermalink }}">
             {{ .Date.Format "2006-01-02" }}
             {{ .Title }}
         </a>


### PR DESCRIPTION
## Problem

Preview deployments (e.g. `https://post-*.zt-dev.pages.dev/`) linked back to
production: clicking a post title, next/prev, a recent-posts entry, or a tag on
a preview navigated to `https://zt.dev/...`, and CSS/fonts/favicon loaded from
`zt.dev` too.

## Cause

`baseURL = "https://zt.dev/"` is baked into every URL produced by `.Permalink`
and `absURL`. Because the build doesn't override `baseURL` per deployment, those
absolute URLs point at production regardless of which host is serving the page.

## Fix

Switch internal navigation and static assets to host-relative output:

- `.Permalink` → `.RelPermalink` for post-title links, next/prev, recent-posts,
  TOC anchors, and relative covers.
- `absURL` → `relURL` for `style.css`, `nova.css`, the preloaded font, the
  favicon, tag links, and cover images.

Left absolute on purpose:

- **Canonical** (`head.html`) stays `.Permalink` so search engines credit the
  production URL, not the preview.
- **RSS** (`rss.xml`) keeps absolute URLs, which feeds require.

Result: the same built HTML works on any host (production, preview, or local)
without a per-deployment `baseURL` override.

## Note

An alternative is to override `baseURL` at build time for non-production
branches (`hugo -b "$CF_PAGES_URL"` in the Cloudflare Pages build command). This
PR takes the template route instead so the output is domain-agnostic and needs
no dashboard configuration.
