### PR TITLE
Drop the internal project name from the experiments post

### DIFF
--- a/content/posts/gvisor-shared-base-experiments.md
+++ b/content/posts/gvisor-shared-base-experiments.md
@@ -114,7 +114,7 @@ if (idx % 2 == 0) {
 }
 ```
 
-The LLIFS rule is that absent is never zero: a page that has not been verified and
+The design rule is that absent is never zero: a page that has not been verified and
 populated yet must fault and be filled from the verified base, and a page the manifest
 says is zero must be installable without any fetch.
 


### PR DESCRIPTION
One-line change: "The LLIFS rule" becomes "The design rule" in Test 1. Removes the only reference to the internal project name from the published post.